### PR TITLE
Use "and" logical operator instead of &&

### DIFF
--- a/task.py
+++ b/task.py
@@ -81,7 +81,7 @@ class Task:
     self.data_local = True
     SHUFFLE_READ_METRICS_KEY = "Shuffle Read Metrics"
     if SHUFFLE_READ_METRICS_KEY not in task_metrics:
-      if (task_info["Locality"] != "NODE_LOCAL") && (task_info["Locality"] != "PROCESS_LOCAL"):
+      if (task_info["Locality"] != "NODE_LOCAL") and (task_info["Locality"] != "PROCESS_LOCAL"):
         self.data_local = False
       self.has_fetch = False
       return


### PR DESCRIPTION
&& doesn't work (at least out of the box) with my python setup (2.7.3 on ubuntu) and, if I'm not mistaken, it's not idiomatic to python